### PR TITLE
Fix anime list empty placeholder check

### DIFF
--- a/src/components/Private/ListPage.jsx
+++ b/src/components/Private/ListPage.jsx
@@ -94,7 +94,7 @@ const ListPage = React.memo(({animes}) => {
                 </div>
                 
             </div>
-            {filteredAnimes === 0 ? <div className='listpage__empty'>ssd</div> : null}
+            {filteredAnimes.length === 0 ? <div className='listpage__empty'>No anime found.</div> : null}
             {filteredAnimes.map(anime => (
                 <div className="card__wrapper">
                     <div className='card'>


### PR DESCRIPTION
## Summary
- handle empty filtered anime results properly
- show a friendly message when nothing matches

## Testing
- `CI=true npm test --silent -- --watchAll=false` *(fails: Target container is not a DOM element)*

------
https://chatgpt.com/codex/tasks/task_e_6864188443fc8322b35c076158c3ba98